### PR TITLE
Fixed incorrect link for 'Sequence Model' in index

### DIFF
--- a/andrewng-p-4-convolutional-neural-network.md
+++ b/andrewng-p-4-convolutional-neural-network.md
@@ -8,7 +8,8 @@ This is the fourth course of the deep learning specialization at [Coursera](http
 * [**Part 2 : Improving Deep Neural Networks: Hyperparameter tuning, Regularization and Optimization**](https://github.com/ashishpatel26/Andrew-NG-Notes/blob/master/andrewng-p-2-improving-deep-learning-network.md)
 * [**Part-3: Structuring Machine Learning Projects**](https://github.com/ashishpatel26/Andrew-NG-Notes/blob/master/andrewng-p-3-structuring-ml-projects.md)
 * [**Part-4 :Convolutional Neural Networks**](https://github.com/ashishpatel26/Andrew-NG-Notes/blob/master/andrewng-p-4-convolutional-neural-network.md)
-* [**Part-5 : Sequence Models**](https://www.kaggle.com/ashishpatel26/andrewng-p-5-sequence-models)
+* [**Part-5 : Sequence Models**](https://github.com/ashishpatel26/Andrew-NG-Notes/blob/master/andrewng-p-5-sequence-models.md)
+
 
 ## Table of contents
 

--- a/andrewng-p-5-sequence-models.md
+++ b/andrewng-p-5-sequence-models.md
@@ -8,7 +8,8 @@ This is the fifth and final course of the deep learning specialization at [Cours
 * [**Part 2 : Improving Deep Neural Networks: Hyperparameter tuning, Regularization and Optimization**](https://github.com/ashishpatel26/Andrew-NG-Notes/blob/master/andrewng-p-2-improving-deep-learning-network.md)
 * [**Part-3: Structuring Machine Learning Projects**](https://github.com/ashishpatel26/Andrew-NG-Notes/blob/master/andrewng-p-3-structuring-ml-projects.md)
 * [**Part-4 :Convolutional Neural Networks**](https://github.com/ashishpatel26/Andrew-NG-Notes/blob/master/andrewng-p-4-convolutional-neural-network.md)
-* [**Part-5 : Sequence Models**](https://www.kaggle.com/ashishpatel26/andrewng-p-5-sequence-models)
+* [**Part-5 : Sequence Models**](https://github.com/ashishpatel26/Andrew-NG-Notes/blob/master/andrewng-p-5-sequence-models.md)
+
 
 ## Table of contents
 * [Sequence Models](#sequence-models)


### PR DESCRIPTION
Hello,
The link in the files `andrewng-p-4-convolutional-neural-network.md` and `andrewng-p-5-convolutional-neural-network.md` were having wrong link for index item **Part-5 : Sequence Models**